### PR TITLE
Fix serious bugs in attention architecture

### DIFF
--- a/model/block.py
+++ b/model/block.py
@@ -68,16 +68,16 @@ class GPTNeoBlockWithSelfAblation(HookedRootModule):
         # Process x_clean
         attn_output_clean = self.attn(self.ln_1(x_clean), self.ln_1(x_clean))
         attn_output_clean = self.attn_hook(attn_output_clean)
-        
-        x_clean = x_clean + attn_output_clean
-        x_clean = x_clean + self.mlp(self.ln_2(x_clean))
-        x_clean = self.mlp_hook(x_clean)
 
         if not is_preliminary_pass:
             # Process x_ablated with ablations
             attn_output_ablated = self.attn(self.ln_1(x_ablated), self.ln_1(x_clean), attn_ablation)
             x_ablated = x_ablated + attn_output_ablated
             x_ablated = x_ablated + self.mlp(self.ln_2(x_ablated), neuron_ablation)
+
+        x_clean = x_clean + attn_output_clean
+        x_clean = x_clean + self.mlp(self.ln_2(x_clean))
+        x_clean = self.mlp_hook(x_clean)
 
         outputs = dict()
         outputs["x_ablated"] = None if is_preliminary_pass else x_ablated


### PR DESCRIPTION
This makes two changes to cause the (ablated) output of the GPTNeoWithSelfAblation model to equal the output of HookedTransformer with ablation hooks added (the attention one as a hook_z and the MLP one as a hook_mlp_post):

* The first change affects what happens when a sequence position is attending to itself (i.e. the diagonal elements of the attention scores/pattern matrices). Before this fix, we were using the clean values for K and V not just for the previous token positions (which makes sense), but also for the same token position (which does not make sense because it's supposed to be calculating it as if this one token position is ablated). The two changes to attention.py fix this issue and make the result numerically equal to what it would be if we used ablated values for K and V along this diagonal, but in an efficient way.
** NOTE: It appears to me that perhaps a simpler and more straightforward way to deal with this issue would be changing the causal mask so that a token position can't attend to itself at all in the first place, but only (strictly) previous token positions. But this code is working without that other architecture change so let's go with it for now I guess?

* The second change is fixing a bug that went unnoticed for a long time where the value we were passing in for x_clean into the attention layer already had the attention and MLP results for that block added to it. So we were basically passing in the value of x_ablated at the beginning of the block (as makes sense) but passing the value of x_clean at the end of the block (which makes no sense at all and is likely the cause of the "information smuggling" phenomenon seen in e.g. "lbl-fixed-sweep-0-k=2"... at least that's my conjecture). The fix for this is simply flipping the order of two blocks of code so that we're using the value of x_clean from the beginning of the block.

Overall, the reason this stuff is so complicated and that we had it wrong for so long is that if you go token-by-token what we want to do is conceptually really simple (i.e. only apply ablations to the current token and not to any preceding tokens), but for training performance we have no choice but to compute everything in parallel, but we still want the *results* of that parallel computation to be identical to what happens if you go token-by-token. I believe the code in this PR now achieves this (but we weren't doing it right before).